### PR TITLE
fixup! Simplify website publishing logic

### DIFF
--- a/website/build.gradle
+++ b/website/build.gradle
@@ -125,17 +125,9 @@ task commitWebsite << {
   // get the latest commit on master
   def latestCommit = grgit.log(maxCommits: 1)[0].abbreviatedId
 
-  // Make sure we are sync'd to the gitbox head
-  if (!git.remote.list().find { it.name == 'test-upstream' }) {
-    println "Adding test-upstream remote"
-    git.remote.add(name: 'test-upstream',
-                   url: 'https://gitbox.apache.org/repos/asf/beam.git')
-  }
-  shell "git fetch origin"
-  shell "git fetch test-upstream asf-site"
+  shell "git fetch origin asf-site"
   git.checkout(branch: 'asf-site')
-  shell "git reset --hard test-upstream/asf-site"
-  shell "git remote remove test-upstream"
+  shell "git reset --hard origin/asf-site"
 
   // Delete the previous content.
   git.remove(patterns: [ 'website/generated-content' ])
@@ -184,18 +176,9 @@ task publishWebsite << {
     println 'No changes to push'
     return
   }
-  if (!git.remote.list().find { it.name == 'website-publish' }) {
-    println "Adding website-publish remote"
-    // Cannot authenticate to the default github uri, so specify gitbox.
-    git.remote.add(name: 'website-publish',
-                   url: 'https://gitbox.apache.org/repos/asf/beam.git')
-  }
 
   // Because git.push() fails to authenticate, run git push directly.
-  shell "git fetch website-publish asf-site"
-  shell "git merge website-publish/asf-site --no-edit"
-  shell "git push website-publish asf-site < /dev/null"
-  shell "git remote remove website-publish"
+  shell "git push https://gitbox.apache.org/repos/asf/beam.git asf-site"
 }
 
 commitWebsite.dependsOn testWebsite


### PR DESCRIPTION
Reference the gitbox remote by URL rather than as a named remote.
This removes the necessary logic to maintain the config and cached
state on the Jenkins machine.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




